### PR TITLE
Bind to a random port instead of 5000 or whatever is passed on the command line

### DIFF
--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -86,7 +86,7 @@ class LiveServer(object):
         return '<LiveServer listening at %s>' % self.url()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def live_server(request, app):
     """Run application in a separate process.
 

--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -17,15 +17,6 @@ from .fixtures import (
 )
 
 
-def pytest_addoption(parser):
-    group = parser.getgroup('flask')
-    group.addoption('--liveserver-port',
-        type=int, metavar='port', default=None,
-        help="port uses to run live server when 'live_server' fixture "
-             "is applied."
-    )
-
-
 class JSONResponse(object):
     """Mixin with testing helper methods for JSON responses."""
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ the ``url_for`` function:
 
 .. code:: python
 
+    from flask import url_for
+
     @pytest.mark.usefixtures('live_server')
     class TestLiveServer:
 

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -16,26 +16,20 @@ class TestLiveServer:
         assert live_server._process.is_alive()
 
     def test_server_url(self, live_server):
-        assert live_server.url() == 'http://localhost:5000'
-        assert live_server.url('/ping') == 'http://localhost:5000/ping'
+        assert live_server.url() == 'http://localhost:%d' % live_server.port
+        assert live_server.url('/ping') == 'http://localhost:%d/ping' % live_server.port
 
     def test_server_listening(self, live_server):
         res = urlopen(live_server.url('/ping'))
         assert res.code == 200
         assert b'pong' in res.read()
 
-    @pytest.mark.app(liveserver_port=5042)
-    def test_custom_server_port(self, live_server):
-        assert live_server.url() == 'http://localhost:5042'
-        assert url_for('index', _external=True) == 'http://localhost:5042/'
-
     def test_url_for(self, live_server):
-        assert url_for('ping', _external=True) == 'http://localhost:5000/ping'
+        assert url_for('ping', _external=True) == 'http://localhost:%s/ping' % live_server.port
 
     def test_set_application_server_name(self, live_server):
-        assert live_server.app.config['SERVER_NAME'] == 'localhost:5000'
+        assert live_server.app.config['SERVER_NAME'] == 'localhost:%d' % live_server.port
 
-    @pytest.mark.app(liveserver_port=5042)
     @pytest.mark.app(server_name='example.com:5000')
     def test_rewrite_application_server_name(self, live_server):
-        assert live_server.app.config['SERVER_NAME'] == 'example.com:5042'
+        assert live_server.app.config['SERVER_NAME'] == 'example.com:%d' % live_server.port


### PR DESCRIPTION
This allows running tests in parallel using pytest-xdist. Without this change each process tries to start the server on the same port, and can mean the server is stopped before the last test has completed.