### PR TITLE
Release the random port before starting the application

### DIFF
--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -104,8 +104,8 @@ def live_server(request, app):
     # Bind to an open port
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(('', 0))
-    s.listen(1)
     port = s.getsockname()[1]
+    s.close()
 
     def rewrite_server_name(server_name, new_port):
         """Rewrite server port in ``server_name`` with ``new_port`` value."""
@@ -125,7 +125,6 @@ def live_server(request, app):
 
     server = LiveServer(app, port)
     request.addfinalizer(server.stop)
-    request.addfinalizer(s.close)
     request.addfinalizer(restore_server_name)
     return server
 


### PR DESCRIPTION
It looks like listening on the random port can cause the application to be unable to start. It works fine on my local OS X instance, but fails in Travis-CI (running on Linux). I have been able to resolve this by closing the socket and then reusing the port for the application.

A failed Travis-CI build:
https://travis-ci.org/davehunt/mozwebqa-test-templates/jobs/48327198

A passing Travis-CI build (using my fork/branch):
https://travis-ci.org/davehunt/mozwebqa-test-templates/jobs/48478829

The failing build times out. I was able to determine through debugging that the address was not available. Closing the socket fixed this. Ideally we'd have a way of starting an application on a random available port. I believe this can be done by passing `0` however there's then no way to determine the port that was selected.