### PR TITLE
Make live_server not start up automatically

### DIFF
--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -53,7 +53,6 @@ class LiveServer(object):
         self.app = app
         self.port = port
         self._process = None
-        self.start()
 
     def start(self):
         """Start application in a separate process."""

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -12,6 +12,8 @@ from flask import url_for
 class TestLiveServer:
 
     def test_server_is_alive(self, live_server):
+        assert live_server._process is None
+        live_server.start()
         assert live_server._process
         assert live_server._process.is_alive()
 
@@ -20,6 +22,7 @@ class TestLiveServer:
         assert live_server.url('/ping') == 'http://localhost:%d/ping' % live_server.port
 
     def test_server_listening(self, live_server):
+        live_server.start()
         res = urlopen(live_server.url('/ping'))
         assert res.code == 200
         assert b'pong' in res.read()
@@ -33,3 +36,13 @@ class TestLiveServer:
     @pytest.mark.app(server_name='example.com:5000')
     def test_rewrite_application_server_name(self, live_server):
         assert live_server.app.config['SERVER_NAME'] == 'example.com:%d' % live_server.port
+
+    def test_live_server_can_add_endpoints(self, live_server):
+        @live_server.app.route("/new-endpoint/")
+        def _new_endpoint():
+            return "got it", 200
+        live_server.start()
+        res = urlopen(live_server.url('/new-endpoint/'))
+        assert res.code == 200
+        assert b'got it' in res.read()
+


### PR DESCRIPTION
By starting up automatically the live server imposes some high costs on
tests that need it when they may not be ready yet. If we allow the user
to specify when the live server starts we can allow them to add new
routes to the server that they only need for the test. This is very
useful for people writing libraries to be used in flask rather than
writing applications using flask