### PR TITLE
Optional live server start

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -139,6 +139,41 @@ other headless browsers).
             assert res.code == 200
 
 
+``--start-live-server`` - start live server automatically (default)
+```````````````````````````````````````````````````````````````````
+
+
+``--no-start-live-server`` - don't start live server automatically
+``````````````````````````````````````````````````````````````````
+
+By default the server is starting automatically whenever you reference
+``live_server`` fixture in your tests. But starting live server imposes some
+high costs on tests that need it when they may not be ready yet. To prevent
+that behaviour pass ``--no-start-live-server`` into your default options (for
+example, in your project's ``pytest.ini`` file)::
+
+    [pytest]
+    addopts = --no-start-live-server
+
+.. note::
+
+    Your **should manually start** live server after you finish your application
+    configuration and define all required routes:
+
+    .. code:: python
+
+        def test_add_endpoint_to_live_server(live_server):
+            @live_server.app.route('/test-endpoint')
+            def test_endpoint():
+                return 'got it', 200
+
+            live_server.start()
+
+            res = urlopen(url_for('test_endpoint', _external=True))
+            assert res.code == 200
+            assert b'got it' in res.read()
+
+
 ``request_ctx`` - request context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pytest_flask/__init__.py
+++ b/pytest_flask/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -53,7 +53,6 @@ class LiveServer(object):
         self.app = app
         self.port = port
         self._process = None
-        self.start()
 
     def start(self):
         """Start application in a separate process."""
@@ -124,6 +123,9 @@ def live_server(request, app, monkeypatch):
                         _rewrite_server_name(server_name, str(port)))
 
     server = LiveServer(app, port)
+    if request.config.getvalue('start_live_server'):
+        server.start()
+
     request.addfinalizer(server.stop)
     return server
 

--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -118,7 +118,7 @@ def pytest_addoption(parser):
     group.addoption('--start-live-server',
                     action="store_true", dest="start_live_server", default=True,
                     help="start server automatically when live_server "
-                         "fixture is applyed.")
+                         "fixture is applyed (enabled by default).")
     group.addoption('--no-start-live-server',
                     action="store_false", dest="start_live_server",
                     help="don't start server automatically when live_server "

--- a/pytest_flask/plugin.py
+++ b/pytest_flask/plugin.py
@@ -113,6 +113,18 @@ def _configure_application(request, monkeypatch):
             monkeypatch.setitem(app.config, key.upper(), value)
 
 
+def pytest_addoption(parser):
+    group = parser.getgroup('flask')
+    group.addoption('--start-live-server',
+                    action="store_true", dest="start_live_server", default=True,
+                    help="start server automatically when live_server "
+                         "fixture is applyed.")
+    group.addoption('--no-start-live-server',
+                    action="store_false", dest="start_live_server",
+                    help="don't start server automatically when live_server "
+                         "fixture is applyed.")
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         'markers',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,11 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from textwrap import dedent
 from flask import Flask, jsonify
+
+
+pytest_plugins = 'pytester'
 
 
 @pytest.fixture
@@ -19,3 +23,28 @@ def app():
         return jsonify(ping='pong')
 
     return app
+
+
+@pytest.fixture
+def appdir(testdir):
+    app_root = testdir.tmpdir
+    test_root = app_root.mkdir('tests')
+
+    def create_test_module(code, filename='test_app.py'):
+        f = test_root.join(filename)
+        f.write(dedent(code), ensure=True)
+        return f
+
+    testdir.create_test_module = create_test_module
+
+    testdir.create_test_module('''
+        import pytest
+
+        from flask import Flask
+
+        @pytest.fixture
+        def app():
+            app = Flask(__name__)
+            return app
+    ''', filename='conftest.py')
+    return testdir


### PR DESCRIPTION
As per #33.

- [x] Add options to prevent `live_server` from starting
- [x] Test `--start-live-server`/`--no-start-live-server` options
- [x] Add note into documenation about available options.
