### PR TITLE
Live server subprocess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,89 @@
-# Python bytecode / optimized files
-*.py[co]
-*.egg-info
-build
-dist
-venv
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
-docs/_build
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 
 clean:
 	@rm -rf build dist *.egg-info
-	@find . -name '*.py?' -delete
+	@find . | grep -E '(__pycache__|\.pyc|\.pyo$$)' | xargs rm -rf
 
 
 docs:

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,8 @@ tests_require = []
 
 extras_require = {
     'docs': read('requirements', 'docs.txt').splitlines(),
-    'tests': tests_require
+    'tests': tests_require,
+    'services': ['pytest-services'],
 }
 
 

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 import pytest
 try:
-    from urllib2 import urlopen
-except ImportError:
     from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 from flask import url_for
 
@@ -62,9 +62,9 @@ class TestLiveServer:
         appdir.create_test_module('''
             import pytest
             try:
-                from urllib2 import urlopen
-            except ImportError:
                 from urllib.request import urlopen
+            except ImportError:
+                from urllib2 import urlopen
 
             from flask import url_for
 

--- a/tests/test_live_server.py
+++ b/tests/test_live_server.py
@@ -16,8 +16,8 @@ class TestLiveServer:
         assert live_server._process.is_alive()
 
     def test_server_url(self, live_server):
-        assert live_server.url() == 'http://localhost:%d' % live_server.port
-        assert live_server.url('/ping') == 'http://localhost:%d/ping' % live_server.port
+        assert live_server.url() == 'http://127.0.0.1:%d' % live_server.port
+        assert live_server.url('/ping') == 'http://127.0.0.1:%d/ping' % live_server.port
 
     def test_server_listening(self, live_server):
         res = urlopen(live_server.url('/ping'))
@@ -25,10 +25,10 @@ class TestLiveServer:
         assert b'pong' in res.read()
 
     def test_url_for(self, live_server):
-        assert url_for('ping', _external=True) == 'http://localhost:%s/ping' % live_server.port
+        assert url_for('ping', _external=True) == 'http://127.0.0.1:%s/ping' % live_server.port
 
     def test_set_application_server_name(self, live_server):
-        assert live_server.app.config['SERVER_NAME'] == 'localhost:%d' % live_server.port
+        assert live_server.app.config['SERVER_NAME'] == '127.0.0.1:%d' % live_server.port
 
     @pytest.mark.options(server_name='example.com:5000')
     def test_rewrite_application_server_name(self, live_server):


### PR DESCRIPTION
Please don't merge this yet. It does not have passing tests, and still needs test cases

I'm working on a way to launch flask as a completely separate process using `os.fork` by way of `watcher_getter` (from [pytest-services](https://github.com/pytest-dev/pytest-services)).

The reason I need to use this strategy is that SQLAlchemy configurations become considerably more complex when you have to deal with multiprocessing (see [docs](http://docs.sqlalchemy.org/en/latest/core/pooling.html#using-connection-pools-with-multiprocessing)). I was struggling to get it to work in my existing configuration, and this seemed like the easier option.

Let me know if you have any initial feedback and I'll circle back. Thanks @vitalk!